### PR TITLE
Custom args for any task, property to disable TLS verification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,12 +18,14 @@ And configure it:
 ```kotlin
 oc {
     // Set the path to the oc binary manually or let it be detected from your path
-//    ocBinary = File("${System.getenv("user.home")}/.local/bin/oc")
+    // ocBinary = File("${System.getenv("user.home")}/.local/bin/oc")
     clusterUrl = "https://your.openshift.cluster:443"
     projectName = "your-project"
     // Set either a token file or the token itself. The tokenFile takes precedence, if it exists
     tokenFile = File("service-account.token")
-//    token = "secret-token"
+    // token = "secret-token"
+    // Disable TLS verify in case you are connecting to a dev cluster with self-signed certificate
+    insecure = false
 }
 ```
 
@@ -36,14 +38,22 @@ tasks.register<com.github.g3force.oc.OcApplyTask>("ocApply") {
     }
 }
 ```
-
+Or pass any additional CLI arguments:
+```kotlin
+// Apply all .yaml files in the templates directory without overwriting resources in cluster
+tasks.register<com.github.g3force.oc.OcApplyTask>("ocApply") {
+    args = listOf("--overwrite=false")
+    source = fileTree("${projectDir}/templates") {
+        include("*.yaml")
+    }
+}
+```
 You can also define your own custom tasks:
 ```kotlin
 tasks.register<com.github.g3force.oc.OcExecTask>("ocGetMyService") {
     args = listOf("get", "service", "my-service")
-    showOutput = true
     dependsOn(tasks.findByPath(":ocProject"))
 }
 ```
 
-Also take the [example project](./example) as a reference.
+Also, take the [example project](./example) as a reference.

--- a/src/main/kotlin/com/github/g3force/oc/OcApplyTask.kt
+++ b/src/main/kotlin/com/github/g3force/oc/OcApplyTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-
 abstract class OcApplyTask : OcExecTask() {
 
     @get:InputFiles
@@ -13,7 +12,7 @@ abstract class OcApplyTask : OcExecTask() {
 
     @TaskAction
     override fun doAction() {
-        source.forEach { f -> applyFile(f) }
+        source.forEach { applyFile(it) }
     }
 
     private fun applyFile(file: File) {

--- a/src/main/kotlin/com/github/g3force/oc/OcExecTask.kt
+++ b/src/main/kotlin/com/github/g3force/oc/OcExecTask.kt
@@ -5,58 +5,51 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
 
 abstract class OcExecTask : DefaultTask() {
-
-    private val logger: Logger = LoggerFactory.getLogger(OcExecTask::class.java)
-
     @Input
-    var args: List<String> = emptyList()
-
-    @Input
-    var showOutput: Boolean = false
+    var args: List<String> = ArrayList()
 
     @TaskAction
     open fun doAction() {
-        execute(args)
+        execute(emptyList())
     }
 
-    fun execute(arguments: List<String>) {
-        val command: MutableList<String> = mutableListOf(findOcBinary())
-        command.addAll(arguments)
+    fun execute(baseCommand: List<String>) {
+        val config = project.extensions.getByType(OcPluginExtension::class.java)
+        val binary = findOcBinary(config.ocBinary)
+
+        val command: MutableList<String> = mutableListOf(binary)
+        if (config.insecure) {
+            command.add("--insecure-skip-tls-verify")
+        }
+
+        command.addAll(baseCommand)
+        command.addAll(args)
 
         logger.info("Executing: ${command.joinToString(" ")}")
 
-        val pb = ProcessBuilder(command)
+        val processBuilder = ProcessBuilder(command)
                 .directory(File("."))
                 .redirectErrorStream(true)
-        pb.environment()["KUBECONFIG"] = "build/kube.config"
-        val proc = pb.start()
-        val errorCode = proc.waitFor()
+        processBuilder.environment()["KUBECONFIG"] = "build/kube.config"
+        val process = processBuilder.start()
+        val errorCode = process.waitFor()
 
-        val reader = BufferedReader(InputStreamReader(proc.inputStream))
+        val reader = BufferedReader(InputStreamReader(process.inputStream))
         val output = IOUtils.readLines(reader).joinToString("\n")
 
         logger.info("Output: \n${output}")
 
-        if (showOutput) {
-            println(command.joinToString(" "))
-            println(output)
-        }
-
         if (errorCode != 0) {
-            throw GradleException("Non zero error code '$errorCode' for command ${pb.command()}:\n${output}")
+            throw GradleException("Non zero error code '$errorCode' for command ${processBuilder.command()}:\n${output}")
         }
     }
 
-    private fun findOcBinary(): String {
-        val config = project.extensions.getByType(OcPluginExtension::class.java)
-        val configuredBinary = config.ocBinary
+    private fun findOcBinary(configuredBinary: File?): String {
         if (configuredBinary?.exists() == true) {
             return configuredBinary.absolutePath
         }

--- a/src/main/kotlin/com/github/g3force/oc/OcLoginTask.kt
+++ b/src/main/kotlin/com/github/g3force/oc/OcLoginTask.kt
@@ -13,7 +13,6 @@ abstract class OcLoginTask : OcExecTask() {
             config.token = tokenFile.readText()
         }
 
-        args = listOf("login", config.clusterUrl, "--token", config.token)
-        super.doAction()
+        execute(listOf("login", config.clusterUrl, "--token", config.token))
     }
 }

--- a/src/main/kotlin/com/github/g3force/oc/OcPluginExtension.kt
+++ b/src/main/kotlin/com/github/g3force/oc/OcPluginExtension.kt
@@ -2,11 +2,11 @@ package com.github.g3force.oc
 
 import java.io.File
 
-
 abstract class OcPluginExtension {
     var ocBinary: File? = null
     var clusterUrl: String = ""
     var projectName: String = ""
     var token: String = ""
     var tokenFile: File? = null
+    var insecure = false
 }

--- a/src/main/kotlin/com/github/g3force/oc/OcProjectTask.kt
+++ b/src/main/kotlin/com/github/g3force/oc/OcProjectTask.kt
@@ -2,13 +2,11 @@ package com.github.g3force.oc
 
 import org.gradle.api.tasks.TaskAction
 
-
 abstract class OcProjectTask : OcExecTask() {
 
     @TaskAction
     override fun doAction() {
         val config = project.extensions.getByType(OcPluginExtension::class.java)
-        args = listOf("project", config.projectName, "--server", config.clusterUrl)
-        super.doAction()
+        execute(listOf("project", config.projectName, "--server", config.clusterUrl))
     }
 }


### PR DESCRIPTION
Allowing custom args for any task, added extension property to disable TLS verification globally (used for minishift or any other dev cluster with self-signed certificate)